### PR TITLE
Actualiza visualización de código de prerequisitos

### DIFF
--- a/InscripcionMaterias/Views/PensumMaterias/_MateriasAsignadasPartial.cshtml
+++ b/InscripcionMaterias/Views/PensumMaterias/_MateriasAsignadasPartial.cshtml
@@ -245,7 +245,7 @@
 
                             <div class="materia-nombre">@materia.IdMateriaNavigation.Nombre</div>
                             <div class="materia-footer">
-                                <span>@(materia.IdMateriaPrerequisito.HasValue ? materia.IdMateriaNavigation.Codigo : "-")</span>
+                                    <span>@(materia.IdMateriaPrerequisito.HasValue ? materia.IdMateriaPrerequisitoNavigation.Codigo : "-")</span>
                                 <span class="uv-badge">@materia.IdMateriaNavigation.UnidadesValorativas UV</span>
                             </div>
                         </div>


### PR DESCRIPTION
Actualiza visualización de código de prerequisitos

Se ha cambiado la forma en que se muestra el código del prerequisito de la materia. Ahora se utiliza `materia.IdMateriaPrerequisitoNavigation.Codigo` en lugar de `materia.IdMateriaNavigation.Codigo`, lo que permite acceder correctamente a la información del prerequisito.